### PR TITLE
 Implement `add_assign_slice`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,44 @@
+pub type Digit = u64;
+
+/// Computes `a` + `b` + `carry_in`.
+/// 
+/// Returns a tuple `(carry_out, sum)`, where `carry_out` represents the most significant bit, and
+/// `sum` the remaining bits of the result.
+pub fn add_with_carry(a: Digit, b: Digit, carry_in: bool) -> (bool, Digit) {
+    let (sum, carry_out) = a.overflowing_add(b);
+    if carry_out {
+        debug_assert!(sum < Digit::max_value()); 
+        (true, sum + carry_in as Digit)
+    } else {
+        let (sum, carry_out) = sum.overflowing_add(carry_in as Digit);
+        (carry_out, sum)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn test_add_with_carry() {
+        let max_value = Digit::max_value();
+        assert!(add_with_carry(0, 0, false) == (false, 0));
+        assert!(add_with_carry(0, 0, true) == (false, 1));
+        assert!(add_with_carry(0, 1, false) == (false, 1));
+        assert!(add_with_carry(0, 1, true) == (false, 2));
+        assert!(add_with_carry(0, max_value, false) == (false, max_value));
+        assert!(add_with_carry(0, max_value, true) == (true, 0));
+        assert!(add_with_carry(1, 0, false) == (false, 1));
+        assert!(add_with_carry(1, 0, true) == (false, 2));
+        assert!(add_with_carry(1, 1, false) == (false, 2));
+        assert!(add_with_carry(1, 1, true) == (false, 3));
+        assert!(add_with_carry(1, max_value, false) == (true, 0));
+        assert!(add_with_carry(1, max_value, true) == (true, 1));
+        assert!(add_with_carry(max_value, 0, false) == (false, max_value));
+        assert!(add_with_carry(max_value, 0, true) == (true, 0));
+        assert!(add_with_carry(max_value, 1, false) == (true, 0));
+        assert!(add_with_carry(max_value, 1, true) == (true, 1));
+        assert!(add_with_carry(max_value, max_value, false) == (true, max_value - 1));
+        assert!(add_with_carry(max_value, max_value, true) == (true, max_value));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,35 @@
 pub type Digit = u64;
 
-/// Computes `a` + `b` + `carry_in`.
-/// 
-/// Returns a tuple `(carry_out, sum)`, where `carry_out` represents the most significant bit, and
-/// `sum` the remaining bits of the result.
-pub fn add_with_carry(a: Digit, b: Digit, carry_in: bool) -> (bool, Digit) {
-    let (sum, carry_out) = a.overflowing_add(b);
+/// Computes `a` + `b` using long addition, and assigns the result to `a`. If the computation
+/// overflowed, this function returns `true`. Otherwise, it returns `false`.
+pub fn add_assign_slice(a: &mut [Digit], b: &[Digit]) -> bool {
+    let (a_suffix, a_prefix) = a.split_at_mut(b.len());
+    let mut carry = false;
+    for (a_item, b_item) in a_suffix.iter_mut().zip(b) {
+        add_assign_with_carry(a_item, *b_item, &mut carry);
+    }
+    if carry {
+        for a_item in a_prefix {
+           add_assign_with_carry(a_item, 0, &mut carry);
+           if !carry {
+               break;
+           } 
+        }
+    }
+    carry
+}
+
+/// Computes `a` + `b` + `carry`, and assigns the result to `a`. If the computation overflowed,
+/// `carry` is set to `true`. Otherwise, it is set to `false`.
+pub fn add_assign_with_carry(a: &mut Digit, b: Digit, carry: &mut bool) {
+    let (a_out, carry_out) = a.overflowing_add(b);
     if carry_out {
-        debug_assert!(sum < Digit::max_value()); 
-        (true, sum + carry_in as Digit)
+        *a = a_out + *carry as Digit;
+        *carry = carry_out;
     } else {
-        let (sum, carry_out) = sum.overflowing_add(carry_in as Digit);
-        (carry_out, sum)
+        let (a_out, carry_out) = a_out.overflowing_add(*carry as Digit);
+        *a = a_out;
+        *carry = carry_out;
     }
 }
 
@@ -20,25 +38,444 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_add_with_carry() {
+    fn test_add_assign_slice() {
         let max_value = Digit::max_value();
-        assert!(add_with_carry(0, 0, false) == (false, 0));
-        assert!(add_with_carry(0, 0, true) == (false, 1));
-        assert!(add_with_carry(0, 1, false) == (false, 1));
-        assert!(add_with_carry(0, 1, true) == (false, 2));
-        assert!(add_with_carry(0, max_value, false) == (false, max_value));
-        assert!(add_with_carry(0, max_value, true) == (true, 0));
-        assert!(add_with_carry(1, 0, false) == (false, 1));
-        assert!(add_with_carry(1, 0, true) == (false, 2));
-        assert!(add_with_carry(1, 1, false) == (false, 2));
-        assert!(add_with_carry(1, 1, true) == (false, 3));
-        assert!(add_with_carry(1, max_value, false) == (true, 0));
-        assert!(add_with_carry(1, max_value, true) == (true, 1));
-        assert!(add_with_carry(max_value, 0, false) == (false, max_value));
-        assert!(add_with_carry(max_value, 0, true) == (true, 0));
-        assert!(add_with_carry(max_value, 1, false) == (true, 0));
-        assert!(add_with_carry(max_value, 1, true) == (true, 1));
-        assert!(add_with_carry(max_value, max_value, false) == (true, max_value - 1));
-        assert!(add_with_carry(max_value, max_value, true) == (true, max_value));
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [0, 0]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [1, 0]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [0, 1]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [1, 1]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [max_value, 1]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == false);
+        assert!(a == [0, max_value]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == false);
+        assert!(a == [1, max_value]);
+
+        let mut a = [0, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == false);
+        assert!(a == [max_value, max_value]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [1, 0]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [2, 0]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [0, 1]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [1, 1]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [2, 1]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [0, 2]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == false);
+        assert!(a == [1, max_value]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == false);
+        assert!(a == [2, max_value]);
+
+        let mut a = [1, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [0, 1]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [max_value - 1, 1]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [max_value, 1]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [0, 2]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [max_value - 1, 2]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == false);
+        assert!(a == [max_value, max_value]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [max_value, 0];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [max_value - 1, 0]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [0, 1]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [1, 1]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [max_value, 1]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [0, 2]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [1, 2]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [max_value, 2]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [1, 0]);
+
+        let mut a = [0, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [1, 1]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [2, 1]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [0, 2]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [1, 2]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [2, 2]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [0, 3]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [1, 0]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [2, 0]);
+
+        let mut a = [1, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [0, 1]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [max_value, 1]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [0, 2]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [max_value - 1, 2]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == false);
+        assert!(a == [max_value, 2]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == false);
+        assert!(a == [0, 3]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == false);
+        assert!(a == [max_value - 1, 3]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [0, 1]);
+
+        let mut a = [max_value, 1];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [max_value - 1, 1]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [0, max_value]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [1, max_value]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == false);
+        assert!(a == [max_value, max_value]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == true);
+        assert!(a == [1, 0]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == true);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [0, max_value - 1]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [1, max_value -1]);
+
+        let mut a = [0, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [max_value, max_value - 1]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [1, max_value]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == false);
+        assert!(a == [2, max_value]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == true);
+        assert!(a == [1, 0]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == true);
+        assert!(a == [2, 0]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == true);
+        assert!(a == [0, 1]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [1, max_value - 1]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [2, max_value -1]);
+
+        let mut a = [1, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [0, max_value]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 0]) == false);
+        assert!(a == [max_value, max_value]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 0]) == true);
+        assert!(a == [0, 0]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 0]) == true);
+        assert!(a == [max_value - 1, 0]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[0, 1]) == true);
+        assert!(a == [max_value, 0]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[1, 1]) == true);
+        assert!(a == [0, 1]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, 1]) == true);
+        assert!(a == [max_value - 1, 1]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[0, max_value]) == true);
+        assert!(a == [max_value, max_value - 1]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[1, max_value]) == true);
+        assert!(a == [0, max_value]);
+
+        let mut a = [max_value, max_value];
+        assert!(add_assign_slice(&mut a, &[max_value, max_value]) == true);
+        assert!(a == [max_value - 1, max_value]);
+    }
+
+    #[test]
+    fn test_add_assign_with_carry() {
+        let max_value = Digit::max_value();
+
+        let mut a = 0;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == 0);
+        assert!(carry == false);
+
+        let mut a = 0;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == 1);
+        assert!(carry == false);
+
+        let mut a = 0;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 1);
+        assert!(carry == false);
+
+        let mut a = 0;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 2);
+        assert!(carry == false);
+
+        let mut a = 0;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == max_value);
+        assert!(carry == false);
+
+        let mut a = 0;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == 0);
+        assert!(carry == true);
+
+        let mut a = 1;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == 1);
+        assert!(carry == false);
+
+        let mut a = 1;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == 2);
+        assert!(carry == false);
+
+        let mut a = 1;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 2);
+        assert!(carry == false);
+
+        let mut a = 1;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 3);
+        assert!(carry == false);
+
+        let mut a = 1;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == 0);
+        assert!(carry == true);
+
+        let mut a = 1;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == 1);
+        assert!(carry == true);
+
+        let mut a = max_value;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == max_value);
+        assert!(carry == false);
+
+        let mut a = max_value;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 0, &mut carry);
+        assert!(a == 0);
+        assert!(carry == true);
+
+        let mut a = max_value;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 0);
+        assert!(carry == true);
+        
+        let mut a = max_value;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, 1, &mut carry);
+        assert!(a == 1);
+        assert!(carry == true);
+
+        let mut a = max_value;
+        let mut carry = false;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == max_value - 1);
+        assert!(carry == true);
+
+        let mut a = max_value;
+        let mut carry = true;
+        add_assign_with_carry(&mut a, max_value, &mut carry);
+        assert!(a == max_value);
+        assert!(carry == true);
     }
 }


### PR DESCRIPTION
This is the main algorithm behind bignum addition. It assumes that
`a.len()` >= `b.len()`. If this assumption does not hold, `a` will
have to be extended first. This is handled elsewhere, since
`add_assign_slice` does not own its arguments.

In addition to these changes, this PR changes the API of
`add_with_carry` to better fit how it is used in `add_assign_slice`.