### PR TITLE
Implement `mul_add_assign_with_carry`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-/// Computes `a` += `b`, using long addition. If the computation overflows, the carry digit is
-/// returned.
+/// Computes `a` += `b`, using long addition.
+/// 
+/// If the computation overflows, the carry digit is returned.
 pub fn add_assign_big(a: &mut [u32], b: &[u32]) -> u32 {
     let mut carry = 0;
     for (a_i, b_i) in a.iter_mut().zip(b) {
@@ -14,11 +15,22 @@ pub fn add_assign_big(a: &mut [u32], b: &[u32]) -> u32 {
     carry
 }
 
-/// Computes `a` += `b` + `carry`. If the computation overflows, `carry` is set to the carry digit.
+/// Computes `a` += `b` + `carry`.
+/// 
+/// If the computation overflows, `carry` is set to the carry digit.
 pub fn add_assign_with_carry(a: &mut u32, b: u32, carry: &mut u32) {
     let result = *a as u64 + b as u64 + *carry as u64;
     *a = (result & (1 << 32) - 1) as u32;
     *carry = (result >> 32) as u32;
+}
+
+/// Computes `a` += `b` * `c` + `carry`.
+/// 
+/// If the computation overflows, `carry` is set to the carry digit.
+pub fn mul_add_assign_with_carry(a: &mut u32, b: u32, c: u32, carry: &mut u32) {
+    let result = *a as u64 + b as u64 * c as u64 + *carry as u64;
+    *a = (result & (1 << 32) - 1) as u32;
+    *carry = (result >> 32) as u32; 
 }
 
 #[cfg(test)]
@@ -147,6 +159,52 @@ mod tests {
             let mut a = *a_in;
             let mut carry = *carry_in;
             add_assign_with_carry(&mut a, *b, &mut carry);
+            assert!(a == *a_out);
+            assert!(carry == *carry_out);
+        }
+    }
+
+    #[test]
+    fn test_mul_add_assign_with_carry() {
+        static TESTS: &[(u32, u32, u32, u32, u32, u32)] = &[
+            (0, 0, 0, 0, 0, 0),
+            (0, 0, 0, 1, 1, 0),
+            (0, 0, 1, 0, 0, 0),
+            (0, 0, 1, 1, 1, 0),
+            (0, 0, 2, 0, 0, 0),
+            (0, 0, 2, 1, 1, 0),
+            (0, 0, MAX, 0, 0, 0),
+            (0, 0, MAX, 1, 1, 0),
+            (0, 1, 0, 0, 0, 0),
+            (0, 1, 0, 1, 1, 0),
+            (0, 1, 1, 0, 1, 0),
+            (0, 1, 1, 1, 2, 0),
+            (0, 1, 2, 0, 2, 0),
+            (0, 1, 2, 1, 3, 0),
+            (0, 1, MAX, 0, MAX, 0),
+            (0, 1, MAX, 1, 0, 1),
+            (0, 2, 0, 0, 0, 0),
+            (0, 2, 0, 1, 1, 0),
+            (0, 2, 1, 0, 2, 0),
+            (0, 2, 1, 1, 3, 0),
+            (0, 2, 2, 0, 4, 0),
+            (0, 2, 2, 1, 5, 0),
+            (0, 2, MAX, 0, MAX - 1, 1),
+            (0, 2, MAX, 1, MAX, 1),
+            (0, MAX, 0, 0, 0, 0),
+            (0, MAX, 0, 1, 1, 0),
+            (0, MAX, 1, 0, MAX, 0),
+            (0, MAX, 1, 1, 0, 1),
+            (0, MAX, 2, 0, MAX - 1, 1),
+            (0, MAX, 2, 1, MAX, 1),
+            (0, MAX, MAX, 0, 1, MAX - 1),
+            (0, MAX, MAX, 1, 2, MAX - 1),
+        ];
+
+        for (a_in, b, c, carry_in, a_out, carry_out) in TESTS {
+            let mut a = *a_in;
+            let mut carry = *carry_in;
+            mul_add_assign_with_carry(&mut a, *b, *c, &mut carry);
             assert!(a == *a_out);
             assert!(carry == *carry_out);
         }


### PR DESCRIPTION
This is required to implement long multiplication for big integers.